### PR TITLE
Adds Close method to Iterator interface.

### DIFF
--- a/mgo/backend.go
+++ b/mgo/backend.go
@@ -427,6 +427,7 @@ func (q *mquery) Tail(timeout time.Duration) Iterator {
 type Iterator interface {
 	Err() error
 	Done() bool
+	Close() error
 	Next(result interface{}) bool
 	All(result interface{}) error
 }


### PR DESCRIPTION
Pretty self explanatory. It's needed to close a `*mgo.Iter` connection.